### PR TITLE
Feat: recommend todo based on prio

### DIFF
--- a/lib/ex_assignment/helpers.ex
+++ b/lib/ex_assignment/helpers.ex
@@ -1,0 +1,13 @@
+defmodule ExAssignment.Helpers do
+  @doc """
+  Returns the least common multiple for a list of ints.
+  Requires list_of_ints and max_int of this list.
+  """
+  def least_common_multiple(list_of_ints, max_int, current_multiple \\ 1) do
+    if Enum.all?(list_of_ints, fn int -> rem(max_int * current_multiple, int) == 0 end) do
+      max_int * current_multiple
+    else
+      least_common_multiple(list_of_ints, max_int, current_multiple + 1)
+    end
+  end
+end

--- a/lib/ex_assignment/todos.ex
+++ b/lib/ex_assignment/todos.ex
@@ -5,6 +5,7 @@ defmodule ExAssignment.Todos do
 
   import Ecto.Query, warn: false
   alias ExAssignment.Repo
+  alias ExAssignment.Helpers
 
   alias ExAssignment.Todos.Todo
 
@@ -44,12 +45,24 @@ defmodule ExAssignment.Todos do
 
   ASSIGNMENT: ...
   """
-  def get_recommended() do
-    list_todos(:open)
-    |> case do
-      [] -> nil
-      todos -> Enum.take_random(todos, 1) |> List.first()
-    end
+  def recommended(todos) do
+    [%Todo{} | _] = todos
+
+    {priorities, max_priority} =
+      Enum.map_reduce(todos, 0, fn todo, acc ->
+        {
+          todo.priority,
+          if(todo.priority > acc, do: todo.priority, else: acc)
+        }
+      end)
+
+    lcm = Helpers.least_common_multiple(priorities, max_priority)
+
+    todos
+    |> Enum.flat_map(fn todo ->
+      List.duplicate(todo, div(lcm, todo.priority))
+    end)
+    |> Enum.random()
   end
 
   @doc """

--- a/lib/ex_assignment_web/controllers/todo_controller.ex
+++ b/lib/ex_assignment_web/controllers/todo_controller.ex
@@ -7,7 +7,7 @@ defmodule ExAssignmentWeb.TodoController do
   def index(conn, _params) do
     open_todos = Todos.list_todos(:open)
     done_todos = Todos.list_todos(:done)
-    recommended_todo = Todos.get_recommended()
+    recommended_todo = Todos.recommended(open_todos)
 
     render(conn, :index,
       open_todos: open_todos,


### PR DESCRIPTION
The probability of a todo to be recommended corresponds to its urgency,
when compared to the urgency of other todos.

As an example lets consider there are 4 open todos in the list:

- *Prepare lunch* (priority: `20`)
- *Water flowers* (priority: `50`)
- *Shop groceries* (priority: `60`)
- *Buy new flower pots* (priority: `130`)

> **Note**
> A high urgency is encoded as a lower value in the `priority` field of a todo.
> For example a todo with a `priority` of `20` is considered to be more urgent than a todo with a `priority` of `50`.

The probability for recommending *Prepare lunch* should be `~2.5` times as high as recommending *Water flowers*, `~3` times as high as *Shop groceries* and `~6.5` times as high as recommending *Buy new flower pots*.